### PR TITLE
Remove unused `e` var in catch statements

### DIFF
--- a/ServiceRestrictions/ServiceRestrictionsMod.cs
+++ b/ServiceRestrictions/ServiceRestrictionsMod.cs
@@ -46,7 +46,7 @@ namespace ServiceRestrictions
             {
                 _harmony.PatchAll(Assembly.GetExecutingAssembly());
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Debug.Log($"Couldn't Patch Service Restrictions.");
             }

--- a/ServiceRestrictions/Settings/ServiceRestrictionSettings.cs
+++ b/ServiceRestrictions/Settings/ServiceRestrictionSettings.cs
@@ -35,7 +35,7 @@ namespace ServiceRestrictions.Settings
                     return (ServiceRestrictionSettings) serializer.Deserialize(reader);
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return new ServiceRestrictionSettings();
             }


### PR DESCRIPTION
Minor code cleanup - removed some unused vars in catch statements.